### PR TITLE
Guard optional logs when determining report sections

### DIFF
--- a/HealthApp/Views/ReportView/ReportVC.swift
+++ b/HealthApp/Views/ReportView/ReportVC.swift
@@ -100,7 +100,10 @@ class ReportVC: UIViewController {
 
 extension ReportVC: UITableViewDelegate, UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
-        return logs?.isEmpty != false ? 2 : logs!.count
+        if logs?.isEmpty == false {
+            return logs?.count ?? 0
+        }
+        return 2
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {


### PR DESCRIPTION
## Summary
- Safely handle optional log results when calculating table sections in `ReportVC`

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689ef1c4ca94832f994a3de996bcf6c8